### PR TITLE
Allow to propagate date changes only if "Apply" button has been pressed

### DIFF
--- a/dev/App.vue
+++ b/dev/App.vue
@@ -20,10 +20,9 @@
           :end-date="'2018-05-10'"
           :months-to-show="2"
           :start-open="false"
-          :require-apply="true"
           @date-one-selected="val => { inputDateOne = val }"
           @date-two-selected="val => { inputDateTwo = val }"
-          @dates-applied="datesApplied"
+          @closed="onClosed"
         />
       </div>
     </div>
@@ -99,9 +98,9 @@ export default {
       }
       return formattedDates
     },
-    datesApplied(dateOne, dateTwo) {
-      var datesStr = this.formatDates(dateOne, dateTwo)
-      window.alert('Dates Selected: ' + datesStr)
+    onClosed() {
+      var datesStr = this.formatDates(this.inputDateOne, this.inputDateTwo)
+      console.log('Dates Selected: ' + datesStr)
     }
   }
 }

--- a/dev/App.vue
+++ b/dev/App.vue
@@ -20,8 +20,10 @@
           :end-date="'2018-05-10'"
           :months-to-show="2"
           :start-open="false"
+          :require-apply="true"
           @date-one-selected="val => { inputDateOne = val }"
           @date-two-selected="val => { inputDateTwo = val }"
+          @dates-applied="datesApplied"
         />
       </div>
     </div>
@@ -96,6 +98,10 @@ export default {
         formattedDates += ' - ' + format(dateTwo, this.dateFormat)
       }
       return formattedDates
+    },
+    datesApplied(dateOne, dateTwo) {
+      var datesStr = this.formatDates(dateOne, dateTwo)
+      window.alert('Dates Selected: ' + datesStr)
     }
   }
 }

--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -6,7 +6,7 @@
       v-show="showDatepicker"
       :class="wrapperClasses"
       :style="showFullscreen ? undefined : wrapperStyles"
-      v-click-outside="closeDatepicker"
+      v-click-outside="closeDatepickerCancel"
     >
       <div class="mobile-header mobile-only" v-if="showFullscreen">
         <div class="mobile-close" @click="closeDatepicker">
@@ -83,8 +83,8 @@
         </transition-group>
       </div>
       <div class="action-buttons" v-if="mode !== 'single'">
-        <button @click="closeDatepicker">{{ texts.cancel }}</button>
-        <button @click="closeDatepicker" :style="{color: colors.selected}">{{ texts.apply }}</button>
+        <button @click="closeDatepickerCancel">{{ texts.cancel }}</button>
+        <button @click="closeDatepickerApply" :style="{color: colors.selected}">{{ texts.apply }}</button>
       </div>
     </div>
   </transition>
@@ -113,6 +113,7 @@ export default {
     offsetX: { type: Number, default: 0 },
     monthsToShow: { type: Number, default: 2 },
     startOpen: { type: Boolean },
+    requireApply: { type: Boolean, default: false },
     fullscreenMobile: { type: Boolean },
     inline: { type: Boolean },
     mobileHeader: { type: String, default: 'Select date' }
@@ -463,6 +464,21 @@ export default {
       this.positionDatepicker()
       this.setStartDates()
       this.showDatepicker = true
+      this.initialDate1 = this.dateOne
+      this.initialDate2 = this.dateTwo
+    },
+    closeDatepickerCancel() {
+      if (this.showDatepicker) {
+        if (this.requireApply) {
+          this.selectedDate1 = this.initialDate1
+          this.selectedDate2 = this.initialDate2
+        }
+        this.closeDatepicker()
+      }
+    },
+    closeDatepickerApply() {
+      this.closeDatepicker()
+      this.$emit('dates-applied', this.selectedDate1, this.selectedDate2)
     },
     closeDatepicker() {
       if (this.inline) {

--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -6,7 +6,7 @@
       v-show="showDatepicker"
       :class="wrapperClasses"
       :style="showFullscreen ? undefined : wrapperStyles"
-      v-click-outside="closeDatepickerCancel"
+      v-click-outside="closeDatepicker"
     >
       <div class="mobile-header mobile-only" v-if="showFullscreen">
         <div class="mobile-close" @click="closeDatepicker">
@@ -84,7 +84,7 @@
       </div>
       <div class="action-buttons" v-if="mode !== 'single'">
         <button @click="closeDatepickerCancel">{{ texts.cancel }}</button>
-        <button @click="closeDatepickerApply" :style="{color: colors.selected}">{{ texts.apply }}</button>
+        <button @click="closeDatepicker" :style="{color: colors.selected}">{{ texts.apply }}</button>
       </div>
     </div>
   </transition>
@@ -113,7 +113,6 @@ export default {
     offsetX: { type: Number, default: 0 },
     monthsToShow: { type: Number, default: 2 },
     startOpen: { type: Boolean },
-    requireApply: { type: Boolean, default: false },
     fullscreenMobile: { type: Boolean },
     inline: { type: Boolean },
     mobileHeader: { type: String, default: 'Select date' }
@@ -469,20 +468,17 @@ export default {
     },
     closeDatepickerCancel() {
       if (this.showDatepicker) {
-        if (this.requireApply) {
-          this.selectedDate1 = this.initialDate1
-          this.selectedDate2 = this.initialDate2
-        }
+        this.selectedDate1 = this.initialDate1
+        this.selectedDate2 = this.initialDate2
         this.closeDatepicker()
       }
-    },
-    closeDatepickerApply() {
-      this.closeDatepicker()
-      this.$emit('dates-applied', this.selectedDate1, this.selectedDate2)
     },
     closeDatepicker() {
       if (this.inline) {
         return
+      }
+      if (this.showDatepicker) {
+        this.$nextTick(() => this.$emit('closed'))
       }
       this.showDatepicker = false
     },


### PR DESCRIPTION
Hi Mikael,

first of all thanks for sharing your datepicker, I found it very neat and easy to use.
I'd like to suggest a new feature: be able to "Cancel" a date selection, or in other words, require to explicitly press the "Apply" button before the dates are changed.

In my PR you can see that I still propagate the date changes while the user is selecting the date range, but if the user presses Cancel, or clicks outside the date selector, the changes are reverted.
Otherwise, if the user presses "Apply" the new dates are kept as selected.
Also, I've added an explicit event to let the parent app know when dates have been applied following a click on "Apply" button.

To avoid introducing behaviour changes I've wrapped this new feature within a new property "require-apply" set to False by default.

Thanks again for sharing this,

Luca