### PR TITLE
Add isSelectingDateOne to props and set isSelectingDate1 according to…

### DIFF
--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -120,7 +120,8 @@ export default {
       type: Boolean,
       default: () => process.env.NODE_ENV === 'test'
     },
-    trigger: { type: Boolean, default: false }
+    trigger: { type: Boolean, default: false },
+    isSelectingDateOne: { type: Boolean, default: true }
   },
   data() {
     return {
@@ -170,7 +171,7 @@ export default {
       width: 300,
       selectedDate1: '',
       selectedDate2: '',
-      isSelectingDate1: true,
+      isSelectingDate1: this.isSelectingDateOne,
       hoverDate: '',
       alignRight: false,
       triggerPosition: {},

--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -574,6 +574,18 @@ export default {
         return
       }
 
+      if (this.allDatesSelected) {
+        if (isBefore(date, this.selectedDate1)) {
+          this.selectedDate1 = date
+          this.selectedDate2 = ''
+          this.isSelectingDate1 = false
+        } else {
+          this.selectedDate2 = date
+          this.closeDatepicker()
+        }
+        return
+      }
+
       if (this.isSelectingDate1 || isBefore(date, this.selectedDate1)) {
         this.selectedDate1 = date
         this.isSelectingDate1 = false

--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -600,7 +600,7 @@ export default {
       return this.selectedDate1 === date || this.selectedDate2 === date
     },
     isInRange(date) {
-      if (!this.allDatesSelected || this.isSingleMode) {
+      if (this.isSingleMode) {
         return false
       }
 


### PR DESCRIPTION
… it.

See #28
Add isSelectingDateOne to props and set isSelectingDate1 according to it.

No deprecate any API.

Second Commit: color days on hover in range already BEFORE the dateTwo is selected.

Third commit: 
On allDatesSelected let the user change the dateOne and dateTwo like airbnb datepicker