### PR TITLE
add slot specifically for shortcuts menu close icon

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -201,7 +201,8 @@ Vue.use(AirBnbStyleDatepicker, {
 | @next-month        | Event emitted when user changes to next month. Returns array with first date in visible months. `['2019-09-01', '2019-10-01']`                                                                                                   |
 | previous-month-icon | Optional, slot used to override the previous month left arrow icon. Uses default icon if nothing is passed. |
 | next-month-icon | Optional, slot used to override the next month right arrow icon. Uses default icon if nothing is passed. |
-| close-icon | Optional, slot used to override the modal close X icon. Uses default icon if nothing is passed. |
+| close-icon | Optional, slot used to override the mobile close X icon. Uses default icon if nothing is passed. |
+| close-shortcuts-icon | Optional, slot used to override the modal close X icon in the keyboard shortcuts menu. Uses default icon if nothing is passed. |
 
 <br><br> _Example with all properties (not recommended, only to show values)_:
 

--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -112,8 +112,8 @@
             :aria-label="ariaLabels.closeKeyboardShortcutsMenu"
           >
             <slot
-              v-if="$slots['close-icon']"
-              name="close-icon"
+              v-if="$slots['close-shortcuts-icon']"
+              name="close-shortcuts-icon"
             ></slot>
             <div v-else class="asd__mobile-close-icon" aria-hidden="true">X</div>
           </button>

--- a/src/components/__tests__/AirbnbStyleDatepicker.spec.js
+++ b/src/components/__tests__/AirbnbStyleDatepicker.spec.js
@@ -513,12 +513,18 @@ describe('AirbnbStyleDatepicker', () => {
       expect(wrapper.findAll('.asd__day--today').length).toBe(1)
     })
     test('svg icons can be overridden by passing a slot', () => {
-      wrapper = createDatePickerInstance({}, {}, {
+      wrapper = createDatePickerInstance({
+        fullscreenMobile: true,
+        startOpen: true,
+      }, {}, {
         'close-icon': '<span id="close-override">x</span>',
+        'close-shortcuts-icon': '<span id="close-shortcuts-override">x</span>',
         'previous-month-icon': '<span id="previous-override">&larr;</span>',
         'next-month-icon': '<span id="next-override">&rarr;</span>',
       })
+      wrapper.setData({ isMobile: true })
       expect(wrapper.find('#close-override').exists()).toBe(true)
+      expect(wrapper.find('#close-shortcuts-override').exists()).toBe(true)
       expect(wrapper.find('#previous-override').exists()).toBe(true)
       expect(wrapper.find('#next-override').exists()).toBe(true)
     })


### PR DESCRIPTION
a quick bugfix/follow up to the accessibility PR:
Once I installed and tried using 2.0.0, vue started logging a warning due to using the same slot ('close-icon') in 2 places. Fixing this by adding a separate slot for the keyboard shortcuts close icon. 