### PR TITLE
SSR fix

### DIFF
--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -297,9 +297,9 @@ export default {
       alignRight: false,
       triggerPosition: {},
       triggerWrapperPosition: {},
-      viewportWidth: window.innerWidth + 'px',
-      isMobile: window.innerWidth < 768,
-      isTablet: window.innerWidth >= 768 && window.innerWidth <= 1024,
+      viewportWidth: undefined,
+      isMobile: undefined,
+      isTablet: undefined,
       triggerElement: undefined
     }
   },
@@ -446,7 +446,11 @@ export default {
     if (this.sundayFirst) {
       this.setSundayToFirstDayInWeek()
     }
-
+  },
+  mounted() {
+    this.viewportWidth = window.innerWidth + 'px'
+    this.isMobile = window.innerWidth < 768
+    this.isTablet = window.innerWidth >= 768 && window.innerWidth <= 1024
     this._handleWindowResizeEvent = debounce(() => {
       this.positionDatepicker()
       this.setStartDates()
@@ -460,8 +464,7 @@ export default {
     }
     window.addEventListener('resize', this._handleWindowResizeEvent)
     window.addEventListener('click', this._handleWindowClickEvent)
-  },
-  mounted() {
+
     this.triggerElement = this.isTest
       ? document.createElement('input')
       : document.getElementById(this.triggerElementId)

--- a/src/polyfills.js
+++ b/src/polyfills.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 
-if (!Element.prototype.matches) {
+if (typeof Element !== 'undefined' && !Element.prototype.matches) {
   Element.prototype.matches =
     Element.prototype.matchesSelector ||
     Element.prototype.mozMatchesSelector ||


### PR DESCRIPTION
Fixes #21 and makes this component work with server side rendering

- moves window/client related setup logic out of `created()`/`data()` and into `mounted()` 
- only apply Element polyfill if Element exists