### PR TITLE
fixed Duplicate keys detected in short days

### DIFF
--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -48,7 +48,7 @@
           :key="month"
           :style="[monthWidthStyles, {left: (width * index) + 'px'}]"
         >
-          <div class="asd__day-title" v-for="day in daysShort" :key="day">{{ day }}</div>
+          <div class="asd__day-title" v-for="(day, index) in daysShort" :key="index">{{ day }}</div>
         </div>
       </div>
 


### PR DESCRIPTION
When using only the first letter of the word will produce the error.

Using the index as key will fix this.