### PR TITLE
Documentation update: add hoveredInRange property to default colors.

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -140,6 +140,7 @@ Vue.use(AirBnbStyleDatepicker, {
     text: '#565a5c',
     inRangeBorder: '#33dacd',
     disabled: '#fff',
+    hoveredInRange: '#67f6ee'
   },
   texts: {
     apply: 'Apply',


### PR DESCRIPTION
I've updated the documentation because `hoveredInRange` was missing there: ![](https://i.imgur.com/5aq7xUM.png)