### PR TITLE
[FIX] Need double arrow key press with Voice Over on dates button

### DIFF
--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -130,22 +130,9 @@
                     v-if="dayNumber"
                     :date="fullDate"
                     :disabled="isDisabled(fullDate)"
-                    :tabindex="
-                      isDateVisible(fullDate) &&
-                      isSameDate(focusedDate, fullDate)
-                        ? 0
-                        : -1
-                    "
-                    :aria-label="
-                      isDateVisible(fullDate)
-                        ? getAriaLabelForDate(fullDate)
-                        : false
-                    "
-                    @click="
-                      () => {
-                        selectDate(fullDate);
-                      }
-                    "
+                    :tabindex="isDateVisible(fullDate) && isSameDate(focusedDate, fullDate) ? 0 : -1"
+                    :aria-label="isDateVisible(fullDate) ? getAriaLabelForDate(fullDate) : false"
+                    @click="() => { selectDate(fullDate) }"
                   >{{ dayNumber }}</button>
                   </td>
                 </tr>

--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -108,7 +108,6 @@
                     class="asd__day"
                     v-for="({fullDate, dayNumber}, index) in week"
                     :key="index + '_' + dayNumber"
-                    :data-date="fullDate"
                     :ref="`date-${fullDate}`"
                     :class="[{
                       'asd__day--enabled': dayNumber !== 0,
@@ -128,6 +127,7 @@
                     class="asd__day-button"
                     type="button"
                     v-if="dayNumber"
+                    :data-date="fullDate"
                     :date="fullDate"
                     :disabled="isDisabled(fullDate)"
                     :tabindex="isDateVisible(fullDate) && isSameDate(focusedDate, fullDate) ? 0 : -1"
@@ -1303,7 +1303,6 @@ $transition-time: 0.3s;
     line-height: $size;
     height: $size;
     padding: 0;
-    overflow: hidden;
     &--enabled {
       border: $border;
       &:hover {

--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -110,8 +110,6 @@
                     :key="index + '_' + dayNumber"
                     :data-date="fullDate"
                     :ref="`date-${fullDate}`"
-                    :tabindex="isDateVisible(fullDate) && isSameDate(focusedDate, fullDate) ? 0 : -1"
-                    :aria-label="isDateVisible(fullDate) ? getAriaLabelForDate(fullDate) : false"
                     :class="[{
                       'asd__day--enabled': dayNumber !== 0,
                       'asd__day--empty': dayNumber === 0,
@@ -126,15 +124,29 @@
                     :style="getDayStyles(fullDate)"
                     @mouseover="() => { setHoverDate(fullDate) }"
                   >
-                    <button
-                      class="asd__day-button"
-                      type="button"
-                      v-if="dayNumber"
-                      tabindex="-1"
-                      :date="fullDate"
-                      :disabled="isDisabled(fullDate)"
-                      @click="() => { selectDate(fullDate) }"
-                    >{{ dayNumber }}</button>
+                  <button
+                    class="asd__day-button"
+                    type="button"
+                    v-if="dayNumber"
+                    :date="fullDate"
+                    :disabled="isDisabled(fullDate)"
+                    :tabindex="
+                      isDateVisible(fullDate) &&
+                      isSameDate(focusedDate, fullDate)
+                        ? 0
+                        : -1
+                    "
+                    :aria-label="
+                      isDateVisible(fullDate)
+                        ? getAriaLabelForDate(fullDate)
+                        : false
+                    "
+                    @click="
+                      () => {
+                        selectDate(fullDate);
+                      }
+                    "
+                  >{{ dayNumber }}</button>
                   </td>
                 </tr>
               </tbody>


### PR DESCRIPTION
Problem: There was a problem with Voice Over in the dates navigation with arrows (have to tap 2 times for each day).
Solution: Put the tabindex and aria-label on the button, no need to focus the td anymore.