### PR TITLE
Set fullscreenMobile prop to false by default, to match with documentation

### DIFF
--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -234,7 +234,7 @@ export default {
     offsetX: { type: Number, default: 0 },
     monthsToShow: { type: Number, default: 2 },
     startOpen: { type: Boolean },
-    fullscreenMobile: { type: Boolean },
+    fullscreenMobile: { type: Boolean, default: false },
     inline: { type: Boolean },
     mobileHeader: { type: String },
     disabledDates: { type: Array, default: () => [] },


### PR DESCRIPTION
While working with the datepicker, we ran across a problem where the datepicker prop "fullscreenMobile" does not default to false. The documentation says it does, so I changed the default value