### PR TITLE
fix clearing value date-two

### DIFF
--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -467,7 +467,7 @@ export default {
       this.generateYears()
     },
     datePropsCompound(newValue) {
-      if (this.dateOne !== this.selectedDate1) {
+      if (this.dateOne !== this.selectedDate1 || (this.selectedDate2 && this.dateTwo !== this.selectedDate2)) {
         this.startingDate = this.dateOne
         this.setStartDates()
         this.generateMonths()


### PR DESCRIPTION
Fixes #71 

The `datePropsCompound` property watcher's handler now also takes into account `dateTwo` changes.

So when `dateTwo` is set to something programmatically but the `dayOne` is not changed the datepicker will still react on changes and update the UI