### PR TITLE
Add prop to not close after click outside

### DIFF
--- a/src/components/AirbnbStyleDatepicker.vue
+++ b/src/components/AirbnbStyleDatepicker.vue
@@ -250,6 +250,7 @@ export default {
     },
     trigger: { type: Boolean, default: false },
     closeAfterSelect: { type: Boolean, default: false },
+    closeAfterClickOutside: { type: Boolean, default: true }
   },
   data() {
     return {
@@ -593,7 +594,7 @@ export default {
       }
     },
     handleClickOutside(event) {
-      if (event.target.id === this.triggerElementId || !this.showDatepicker || this.inline) {
+      if (event.target.id === this.triggerElementId || !this.showDatepicker || this.inline || !this.closeAfterClickOutside) {
         return
       }
       this.closeDatepicker()


### PR DESCRIPTION
Added a prop to choose whether or not you want to close the datepicker when you click outside of the modal. Added a default of true which maintains the original behavior.